### PR TITLE
chore(deps): update github action for creating images to use @main in…

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build, Tag and Push Docker Image to GHCR
-        uses: GlueOps/github-actions-build-push-containers@v0.1.3
+        uses: GlueOps/github-actions-build-push-containers@main


### PR DESCRIPTION
## **User description**
…stead of being pinned to a version


___

## **Type**
enhancement


___

## **Description**
- Updated the GitHub Action in `.github/workflows/ghcr.yaml` to use the `@main` branch instead of being pinned to a specific version. This change ensures that the workflow always uses the latest version of the GitHub Action for creating Docker images, improving maintainability and access to new features or fixes.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghcr.yaml</strong><dd><code>Update GitHub Action to Use @main for Docker Image Creation</code></dd></summary>
<hr>
      
.github/workflows/ghcr.yaml

<li>Updated the GitHub Action used for building, tagging, and pushing <br>Docker images to use the <code>@main</code> branch instead of a pinned version <br>(<code>v0.1.3</code>).<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/cluster-information-help-page-html/pull/11/files#diff-1c25e13ade0044334e51a0da32e5f58ab84f36f1c0f6c298a3778debab2ed163">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

