### PR TITLE
ci: add PR screenshot workflow for dashboard variations

### DIFF
--- a/.github/workflows/pr-screenshots.yaml
+++ b/.github/workflows/pr-screenshots.yaml
@@ -5,9 +5,13 @@ name: PR Screenshots
 # PR comment. All the heavy lifting lives in e2e-screenshots/screenshot-variations.sh,
 # which is also runnable locally with just Docker.
 #
-# Note: pull requests from forks receive a read-only GITHUB_TOKEN, so the
-# sticky-comment step can't post there. That's expected — internal branch PRs
-# work; fork PRs will still upload the artifact.
+# This is an INFORMATIONAL check: it depends on external best-effort services
+# (litterbox + the npm registry), so the capture step is allowed to fail without
+# failing the PR — an outage should never block a merge. The comment/artifact steps
+# run with `if: always()` so a partial or failed run still surfaces what it can.
+#
+# Note: pull requests from forks get a read-only GITHUB_TOKEN, so the sticky-comment
+# step can't post there; the artifact upload still runs and captures the PNGs.
 
 on:
   pull_request:
@@ -25,25 +29,33 @@ concurrency:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      # Informational: an outage of litterbox / npm must not fail the PR check.
       - name: Build variations, capture screenshots, upload to litterbox
+        id: capture
+        continue-on-error: true
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           LITTERBOX_TIME: 72h
         run: ./e2e-screenshots/screenshot-variations.sh
 
       - name: Post sticky PR comment with screenshots
+        if: always()
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-screenshots
           path: screenshots/comment.md
 
       - name: Upload screenshots as a workflow artifact
+        if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-screenshots
           path: screenshots/*.png
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/.github/workflows/pr-screenshots.yaml
+++ b/.github/workflows/pr-screenshots.yaml
@@ -1,0 +1,49 @@
+name: PR Screenshots
+
+# Renders every dashboard variation, screenshots each, uploads the PNGs to
+# litterbox (anonymous, auto-expiring host), and posts them inline as a sticky
+# PR comment. All the heavy lifting lives in e2e-screenshots/screenshot-variations.sh,
+# which is also runnable locally with just Docker.
+#
+# Note: pull requests from forks receive a read-only GITHUB_TOKEN, so the
+# sticky-comment step can't post there. That's expected — internal branch PRs
+# work; fork PRs will still upload the artifact.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# One in-flight run per PR; a new push cancels the previous screenshot run.
+concurrency:
+  group: pr-screenshots-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Build variations, capture screenshots, upload to litterbox
+        env:
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          LITTERBOX_TIME: 72h
+        run: ./e2e-screenshots/screenshot-variations.sh
+
+      - name: Post sticky PR comment with screenshots
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: pr-screenshots
+          path: screenshots/comment.md
+
+      - name: Upload screenshots as a workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-screenshots
+          path: screenshots/*.png
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# PR screenshot artifacts (e2e-screenshots/screenshot-variations.sh)
+screenshots
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/e2e-screenshots/pr-screenshots.mjs
+++ b/e2e-screenshots/pr-screenshots.mjs
@@ -4,48 +4,72 @@
 // Runs inside the official Playwright container (node + chromium preinstalled),
 // so it has no dependency on the app's own node_modules. Driven entirely by env:
 //
-//   SHOT_TARGETS   JSON array of { "name": "...", "url": "http://app-baseline:8080" }
+//   SHOT_TARGETS   JSON array of { "name": "...", "url": "http://shot-baseline:8080" }
 //   OUT_DIR        directory for the PNGs and comment.md   (default: ./screenshots)
 //   LITTERBOX_TIME retention window: 1h | 12h | 24h | 72h  (default: 72h)
 //   COMMIT_SHA     short SHA, shown in the comment header   (default: "local")
 //   VIEWPORT       "WxH" for the browser viewport           (default: 1440x900)
 //
-// Emits <OUT_DIR>/<name>.png for each target and <OUT_DIR>/comment.md — a
-// ready-to-post Markdown body with the uploaded images embedded inline.
+// Each target is captured and uploaded independently: a failure on one (unreachable
+// container, render error, upload error) is recorded against that variation and the
+// run continues, so comment.md is ALWAYS written with whatever succeeded.
 
 import { chromium } from "playwright";
 import { mkdir, writeFile, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 
 const LITTERBOX_API =
   "https://litterbox.catbox.moe/resources/internals/api.php";
+const NAV_TIMEOUT_MS = 60_000;
+const UPLOAD_TIMEOUT_MS = 60_000;
 
-const targets = JSON.parse(process.env.SHOT_TARGETS || "[]");
 const outDir = process.env.OUT_DIR || "screenshots";
 const time = process.env.LITTERBOX_TIME || "72h";
 const sha = process.env.COMMIT_SHA || "local";
-const [vw, vh] = (process.env.VIEWPORT || "1440x900").split("x").map(Number);
 
-if (targets.length === 0) {
-  console.error("SHOT_TARGETS is empty — nothing to capture.");
+// Parse the viewport, falling back to a sane default on anything malformed.
+let vw = 1440;
+let vh = 900;
+{
+  const [w, h] = (process.env.VIEWPORT || "").split("x").map(Number);
+  if (Number.isFinite(w) && w > 0 && Number.isFinite(h) && h > 0) {
+    vw = w;
+    vh = h;
+  } else if (process.env.VIEWPORT) {
+    console.error(`Ignoring malformed VIEWPORT="${process.env.VIEWPORT}", using ${vw}x${vh}`);
+  }
+}
+
+// Parse + validate SHOT_TARGETS up front with a clear error rather than a raw stack.
+let targets;
+try {
+  targets = JSON.parse(process.env.SHOT_TARGETS || "[]");
+} catch (err) {
+  console.error(`SHOT_TARGETS is not valid JSON: ${err.message}`);
+  process.exit(1);
+}
+if (!Array.isArray(targets) || targets.length === 0) {
+  console.error("SHOT_TARGETS must be a non-empty JSON array — nothing to capture.");
   process.exit(1);
 }
 
-// Upload one file to litterbox and return its public URL. Throws on any
-// non-URL response so the caller can record the failure per-variation rather
-// than aborting the whole run.
+// Filesystem-safe slug so a target name can never escape outDir or collide oddly.
+const slug = (name) => String(name).replace(/[^a-z0-9._-]+/gi, "_");
+
+// Upload one file to litterbox and return its public URL. Throws on any non-URL
+// response (litterbox reports errors as plain text with a 200) or a stall.
 async function uploadToLitterbox(filePath) {
   const bytes = await readFile(filePath);
   const form = new FormData();
   form.set("reqtype", "fileupload");
   form.set("time", time);
-  form.set(
-    "fileToUpload",
-    new Blob([bytes], { type: "image/png" }),
-    filePath.split("/").pop(),
-  );
+  form.set("fileToUpload", new Blob([bytes], { type: "image/png" }), basename(filePath));
 
-  const res = await fetch(LITTERBOX_API, { method: "POST", body: form });
+  const res = await fetch(LITTERBOX_API, {
+    method: "POST",
+    body: form,
+    signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+  });
   const body = (await res.text()).trim();
   if (!res.ok || !body.startsWith("https://")) {
     throw new Error(`litterbox HTTP ${res.status}: ${body.slice(0, 200)}`);
@@ -53,40 +77,48 @@ async function uploadToLitterbox(filePath) {
   return body;
 }
 
+// Kill animations/transitions and the text caret so a shot can't catch a
+// mid-transition frame — a real source of visual-diff noise.
+const STABILIZE_CSS =
+  "*,*::before,*::after{animation:none!important;transition:none!important;caret-color:transparent!important}";
+
 await mkdir(outDir, { recursive: true });
 
 const browser = await chromium.launch();
 const results = [];
 
-for (const { name, url, caption } of targets) {
-  const context = await browser.newContext({
-    viewport: { width: vw, height: vh },
-  });
-  const page = await context.newPage();
-  console.log(`▶ ${name}: ${url}`);
-  await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
-  // Give webfonts/icons a beat to settle so text metrics are stable.
-  await page.waitForTimeout(1_000);
+try {
+  for (const { name, caption, url } of targets) {
+    let context = null;
+    let imageUrl = null;
+    let error = null;
+    try {
+      context = await browser.newContext({ viewport: { width: vw, height: vh } });
+      const page = await context.newPage();
+      console.log(`▶ ${name}: ${url}`);
+      // "load" (not "networkidle") so a chatty/polling page or a slow font CDN
+      // can't stall us; then wait for webfonts so text metrics are stable.
+      await page.goto(url, { waitUntil: "load", timeout: NAV_TIMEOUT_MS });
+      await page.addStyleTag({ content: STABILIZE_CSS });
+      await page.evaluate(() => document.fonts.ready);
 
-  const file = join(outDir, `${name}.png`);
-  await page.screenshot({ path: file, fullPage: true });
-  await context.close();
-
-  let url_ = null;
-  let error = null;
-  try {
-    url_ = await uploadToLitterbox(file);
-    console.log(`  ↑ ${url_}`);
-  } catch (err) {
-    error = String(err.message || err);
-    console.error(`  ✗ upload failed: ${error}`);
+      const file = join(outDir, `${slug(name)}.png`);
+      await page.screenshot({ path: file, fullPage: true });
+      imageUrl = await uploadToLitterbox(file);
+      console.log(`  ↑ ${imageUrl}`);
+    } catch (err) {
+      error = String(err?.message || err);
+      console.error(`  ✗ ${name}: ${error}`);
+    } finally {
+      if (context) await context.close();
+    }
+    results.push({ name, caption, url: imageUrl, error });
   }
-  results.push({ name, caption, url: url_, error });
+} finally {
+  await browser.close();
 }
 
-await browser.close();
-
-// Compose the sticky PR comment.
+// Compose the sticky PR comment — always written, even if some variations failed.
 const lines = [
   `### 📸 UI Screenshots`,
   ``,
@@ -98,16 +130,16 @@ for (const { name, caption, url, error } of results) {
   if (caption) lines.push(`_${caption}_`);
   lines.push(``);
   if (url) lines.push(`![${name}](${url})`);
-  else lines.push(`> ⚠️ upload failed: \`${error}\``);
+  else lines.push(`> ⚠️ failed: \`${error}\``);
   lines.push(``);
 }
 
 await writeFile(join(outDir, "comment.md"), lines.join("\n"));
 console.log(`\n✔ wrote ${join(outDir, "comment.md")}`);
 
-// Non-zero exit if every upload failed, so CI surfaces a hard problem while
-// still tolerating a single flaky variation.
+// Exit non-zero only if EVERY variation failed — a hard problem worth surfacing.
+// Partial success still writes a useful comment and exits 0.
 if (results.every((r) => !r.url)) {
-  console.error("All uploads failed.");
+  console.error("All variations failed.");
   process.exit(1);
 }

--- a/e2e-screenshots/pr-screenshots.mjs
+++ b/e2e-screenshots/pr-screenshots.mjs
@@ -1,0 +1,113 @@
+// Capture a screenshot of each dashboard variation and upload it to litterbox
+// (https://litterbox.catbox.moe) — an anonymous, no-auth, auto-expiring file host.
+//
+// Runs inside the official Playwright container (node + chromium preinstalled),
+// so it has no dependency on the app's own node_modules. Driven entirely by env:
+//
+//   SHOT_TARGETS   JSON array of { "name": "...", "url": "http://app-baseline:8080" }
+//   OUT_DIR        directory for the PNGs and comment.md   (default: ./screenshots)
+//   LITTERBOX_TIME retention window: 1h | 12h | 24h | 72h  (default: 72h)
+//   COMMIT_SHA     short SHA, shown in the comment header   (default: "local")
+//   VIEWPORT       "WxH" for the browser viewport           (default: 1440x900)
+//
+// Emits <OUT_DIR>/<name>.png for each target and <OUT_DIR>/comment.md — a
+// ready-to-post Markdown body with the uploaded images embedded inline.
+
+import { chromium } from "playwright";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const LITTERBOX_API =
+  "https://litterbox.catbox.moe/resources/internals/api.php";
+
+const targets = JSON.parse(process.env.SHOT_TARGETS || "[]");
+const outDir = process.env.OUT_DIR || "screenshots";
+const time = process.env.LITTERBOX_TIME || "72h";
+const sha = process.env.COMMIT_SHA || "local";
+const [vw, vh] = (process.env.VIEWPORT || "1440x900").split("x").map(Number);
+
+if (targets.length === 0) {
+  console.error("SHOT_TARGETS is empty — nothing to capture.");
+  process.exit(1);
+}
+
+// Upload one file to litterbox and return its public URL. Throws on any
+// non-URL response so the caller can record the failure per-variation rather
+// than aborting the whole run.
+async function uploadToLitterbox(filePath) {
+  const bytes = await readFile(filePath);
+  const form = new FormData();
+  form.set("reqtype", "fileupload");
+  form.set("time", time);
+  form.set(
+    "fileToUpload",
+    new Blob([bytes], { type: "image/png" }),
+    filePath.split("/").pop(),
+  );
+
+  const res = await fetch(LITTERBOX_API, { method: "POST", body: form });
+  const body = (await res.text()).trim();
+  if (!res.ok || !body.startsWith("https://")) {
+    throw new Error(`litterbox HTTP ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return body;
+}
+
+await mkdir(outDir, { recursive: true });
+
+const browser = await chromium.launch();
+const results = [];
+
+for (const { name, url, caption } of targets) {
+  const context = await browser.newContext({
+    viewport: { width: vw, height: vh },
+  });
+  const page = await context.newPage();
+  console.log(`▶ ${name}: ${url}`);
+  await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+  // Give webfonts/icons a beat to settle so text metrics are stable.
+  await page.waitForTimeout(1_000);
+
+  const file = join(outDir, `${name}.png`);
+  await page.screenshot({ path: file, fullPage: true });
+  await context.close();
+
+  let url_ = null;
+  let error = null;
+  try {
+    url_ = await uploadToLitterbox(file);
+    console.log(`  ↑ ${url_}`);
+  } catch (err) {
+    error = String(err.message || err);
+    console.error(`  ✗ upload failed: ${error}`);
+  }
+  results.push({ name, caption, url: url_, error });
+}
+
+await browser.close();
+
+// Compose the sticky PR comment.
+const lines = [
+  `### 📸 UI Screenshots`,
+  ``,
+  `Rendered for \`${sha}\` · images expire in **${time}** ([litterbox](https://litterbox.catbox.moe), anonymous host).`,
+  ``,
+];
+for (const { name, caption, url, error } of results) {
+  lines.push(`#### ${name}`);
+  if (caption) lines.push(`_${caption}_`);
+  lines.push(``);
+  if (url) lines.push(`![${name}](${url})`);
+  else lines.push(`> ⚠️ upload failed: \`${error}\``);
+  lines.push(``);
+}
+
+await writeFile(join(outDir, "comment.md"), lines.join("\n"));
+console.log(`\n✔ wrote ${join(outDir, "comment.md")}`);
+
+// Non-zero exit if every upload failed, so CI surfaces a hard problem while
+// still tolerating a single flaky variation.
+if (results.every((r) => !r.url)) {
+  console.error("All uploads failed.");
+  process.exit(1);
+}

--- a/e2e-screenshots/screenshot-variations.sh
+++ b/e2e-screenshots/screenshot-variations.sh
@@ -5,7 +5,7 @@
 # Produces ./screenshots/<name>.png and ./screenshots/comment.md (a ready-to-post
 # Markdown body with the images embedded inline).
 #
-# Runnable locally with nothing but Docker — no node/npm needed on the host:
+# Runnable locally with Docker + openssl + bash 4+ (no node/npm needed on the host):
 #
 #   ./e2e-screenshots/screenshot-variations.sh
 #
@@ -17,6 +17,7 @@
 #   LITTERBOX_TIME    retention: 1h|12h|24h|72h         (default: 72h)
 #   COMMIT_SHA        label shown in the comment        (default: git short SHA)
 #   PLAYWRIGHT_IMAGE  pinned Playwright container        (default below)
+#   PLAYWRIGHT_VERSION npm playwright version            (default: derived from the image tag)
 #   SKIP_BUILD        set to 1 to reuse an existing IMAGE
 
 set -euo pipefail
@@ -25,10 +26,10 @@ CAPTAIN_DOMAIN="${CAPTAIN_DOMAIN:-verylongenvnamehere.anotherverylongtenantnameh
 IMAGE="${IMAGE:-cluster-help-page:pr}"
 LITTERBOX_TIME="${LITTERBOX_TIME:-72h}"
 COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
-PLAYWRIGHT_IMAGE="${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.49.1-noble}"
-# Must match PLAYWRIGHT_IMAGE's tag: the image ships the browsers, we add the
-# matching npm package at runtime (browser download skipped — they're preinstalled).
-PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-1.49.1}"
+PLAYWRIGHT_IMAGE="${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.61.1-noble}"
+# Single source of truth: derive the npm package version from the image tag so the
+# browsers baked into the image and the JS package we add at runtime can't drift.
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-$(printf '%s' "$PLAYWRIGHT_IMAGE" | sed -E 's/.*:v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')}"
 NETWORK="shots-$$"
 OUT_DIR="screenshots"
 
@@ -50,7 +51,11 @@ cleanup() {
   done
   docker network rm "$NETWORK" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
+
+# Minimal JSON string escaping (backslash + double-quote) so hand-built target JSON
+# stays valid even if a caption ever gains a special character.
+json_escape() { local s=$1; s=${s//\\/\\\\}; s=${s//\"/\\\"}; printf '%s' "$s"; }
 
 echo "==> Building $IMAGE"
 if [ "${SKIP_BUILD:-0}" != "1" ]; then
@@ -72,19 +77,36 @@ for v in "${VARIATIONS[@]}"; do
   IFS='|' read -r name internal kubeadm ca caption <<<"$v"
   ca_env=()
   [ "$ca" = "yes" ] && ca_env=(-e "CLUSTER_CA_CERTIFICATE=$FAKE_CA")
+  # Idempotency: clear any leftover container from a hard-killed prior run.
+  docker rm -f "shot-$name" >/dev/null 2>&1 || true
   docker run -d --name "shot-$name" --network "$NETWORK" \
     -e CAPTAIN_DOMAIN="$CAPTAIN_DOMAIN" \
     -e INTERNAL_LB_ENABLED="$internal" \
     -e KUBEADM_ENABLED="$kubeadm" \
-    "${ca_env[@]}" \
+    "${ca_env[@]+"${ca_env[@]}"}" \
     "$IMAGE" >/dev/null
   [ $first -eq 0 ] && targets_json+=","
   first=0
-  targets_json+="{\"name\":\"$name\",\"url\":\"http://shot-$name:8080\",\"caption\":\"$caption\"}"
+  targets_json+="{\"name\":\"$(json_escape "$name")\",\"url\":\"http://shot-$name:8080\",\"caption\":\"$(json_escape "$caption")\"}"
 done
 targets_json+="]"
 
+echo "==> Waiting for containers to serve on :8080"
+for v in "${VARIATIONS[@]}"; do
+  name="${v%%|*}"
+  ready=0
+  for _ in $(seq 1 30); do
+    # 127.0.0.1 (not localhost): nginx listens IPv4-only, busybox wget prefers ::1.
+    if docker exec "shot-$name" wget -q -O /dev/null http://127.0.0.1:8080/ 2>/dev/null; then
+      ready=1; break
+    fi
+    sleep 1
+  done
+  if [ "$ready" = 1 ]; then echo "   ✓ shot-$name"; else echo "   ! shot-$name not ready after 30s (capturing anyway)"; fi
+done
+
 echo "==> Capturing screenshots + uploading to litterbox"
+rm -rf "$OUT_DIR" 2>/dev/null || true   # start clean so no stale PNGs linger/ship
 mkdir -p "$OUT_DIR"
 # Mount only the script (read-only) and an output dir, so npm's node_modules lands
 # in the container's /app, never in the host repo.
@@ -99,5 +121,11 @@ docker run --rm --network "$NETWORK" \
   -e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
   "$PLAYWRIGHT_IMAGE" \
   sh -c "npm i playwright@$PLAYWRIGHT_VERSION --no-save --no-audit --no-fund --silent && node pr-screenshots.mjs"
+
+# The Playwright container runs as root; hand the outputs back to the caller so the
+# host repo doesn't end up with root-owned files (harmless in CI, annoying locally).
+# --user 0 because the app image otherwise runs as the unprivileged nginx user.
+docker run --rm --user 0 --entrypoint chown -v "$REPO_DIR/$OUT_DIR:/out" "$IMAGE" \
+  -R "$(id -u):$(id -g)" /out 2>/dev/null || true
 
 echo "==> Done. See $OUT_DIR/comment.md"

--- a/e2e-screenshots/screenshot-variations.sh
+++ b/e2e-screenshots/screenshot-variations.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Build the dashboard image, run every flag/CA variation as a container, screenshot
+# each with Playwright, and upload the PNGs to litterbox (anonymous, auto-expiring).
+# Produces ./screenshots/<name>.png and ./screenshots/comment.md (a ready-to-post
+# Markdown body with the images embedded inline).
+#
+# Runnable locally with nothing but Docker — no node/npm needed on the host:
+#
+#   ./e2e-screenshots/screenshot-variations.sh
+#
+# and reused verbatim by .github/workflows/pr-screenshots.yaml in CI.
+#
+# Tunables (env):
+#   CAPTAIN_DOMAIN    domain baked into every variation (default: long stress-test value)
+#   IMAGE             image tag to build/use            (default: cluster-help-page:pr)
+#   LITTERBOX_TIME    retention: 1h|12h|24h|72h         (default: 72h)
+#   COMMIT_SHA        label shown in the comment        (default: git short SHA)
+#   PLAYWRIGHT_IMAGE  pinned Playwright container        (default below)
+#   SKIP_BUILD        set to 1 to reuse an existing IMAGE
+
+set -euo pipefail
+
+CAPTAIN_DOMAIN="${CAPTAIN_DOMAIN:-verylongenvnamehere.anotherverylongtenantnamehere.glueops.rocks}"
+IMAGE="${IMAGE:-cluster-help-page:pr}"
+LITTERBOX_TIME="${LITTERBOX_TIME:-72h}"
+COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+PLAYWRIGHT_IMAGE="${PLAYWRIGHT_IMAGE:-mcr.microsoft.com/playwright:v1.49.1-noble}"
+# Must match PLAYWRIGHT_IMAGE's tag: the image ships the browsers, we add the
+# matching npm package at runtime (browser download skipped — they're preinstalled).
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-1.49.1}"
+NETWORK="shots-$$"
+OUT_DIR="screenshots"
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+# name  internal_lb  kubeadm  ca(yes|no)  caption
+# kubeadm variations always carry a CA — a kubeadm cluster is never without one.
+VARIATIONS=(
+  "baseline|FALSE|FALSE|no|internal LB off · kubeadm off"
+  "internal|TRUE|FALSE|no|internal LB on · kubeadm off"
+  "kubeadm|FALSE|TRUE|yes|kubeadm on · CA present"
+  "both|TRUE|TRUE|yes|internal LB on · kubeadm on · CA present"
+)
+
+cleanup() {
+  for v in "${VARIATIONS[@]}"; do
+    docker rm -f "shot-${v%%|*}" >/dev/null 2>&1 || true
+  done
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> Building $IMAGE"
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  docker build -t "$IMAGE" .
+fi
+
+echo "==> Generating throwaway fake CA (test-only, no private key kept)"
+# Fixed short CN — X.509 caps CN at 64 chars, and the value is irrelevant to
+# what the dashboard renders (it only base64-encodes the PEM into the kubeconfig).
+FAKE_CA="$(openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+  -keyout /dev/null 2>/dev/null \
+  -subj "/CN=glueops-test-fake-ca/O=GlueOps-Test")"
+
+echo "==> Creating network $NETWORK and starting variation containers"
+docker network create "$NETWORK" >/dev/null
+targets_json="["
+first=1
+for v in "${VARIATIONS[@]}"; do
+  IFS='|' read -r name internal kubeadm ca caption <<<"$v"
+  ca_env=()
+  [ "$ca" = "yes" ] && ca_env=(-e "CLUSTER_CA_CERTIFICATE=$FAKE_CA")
+  docker run -d --name "shot-$name" --network "$NETWORK" \
+    -e CAPTAIN_DOMAIN="$CAPTAIN_DOMAIN" \
+    -e INTERNAL_LB_ENABLED="$internal" \
+    -e KUBEADM_ENABLED="$kubeadm" \
+    "${ca_env[@]}" \
+    "$IMAGE" >/dev/null
+  [ $first -eq 0 ] && targets_json+=","
+  first=0
+  targets_json+="{\"name\":\"$name\",\"url\":\"http://shot-$name:8080\",\"caption\":\"$caption\"}"
+done
+targets_json+="]"
+
+echo "==> Capturing screenshots + uploading to litterbox"
+mkdir -p "$OUT_DIR"
+# Mount only the script (read-only) and an output dir, so npm's node_modules lands
+# in the container's /app, never in the host repo.
+docker run --rm --network "$NETWORK" \
+  -v "$REPO_DIR/e2e-screenshots/pr-screenshots.mjs:/app/pr-screenshots.mjs:ro" \
+  -v "$REPO_DIR/$OUT_DIR:/out" \
+  -w /app \
+  -e SHOT_TARGETS="$targets_json" \
+  -e OUT_DIR="/out" \
+  -e LITTERBOX_TIME="$LITTERBOX_TIME" \
+  -e COMMIT_SHA="$COMMIT_SHA" \
+  -e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+  "$PLAYWRIGHT_IMAGE" \
+  sh -c "npm i playwright@$PLAYWRIGHT_VERSION --no-save --no-audit --no-fund --silent && node pr-screenshots.mjs"
+
+echo "==> Done. See $OUT_DIR/comment.md"

--- a/e2e-screenshots/screenshot-variations.sh
+++ b/e2e-screenshots/screenshot-variations.sh
@@ -45,11 +45,27 @@ VARIATIONS=(
   "both|TRUE|TRUE|yes|internal LB on · kubeadm on · CA present"
 )
 
+# If the run aborts before pr-screenshots.mjs writes comment.md (docker build,
+# image pull, or npm install failed), leave an honest placeholder so the sticky
+# PR comment reflects THIS run rather than going silent or keeping a stale prior
+# comment. Never overwrites a real comment written by the capture step.
+write_fallback_comment() {
+  [ -f "$OUT_DIR/comment.md" ] && return
+  mkdir -p "$OUT_DIR"
+  {
+    echo "### 📸 UI Screenshots"
+    echo ""
+    echo "⚠️ Screenshot run for \`$COMMIT_SHA\` aborted before any screenshots were captured"
+    echo "(image build, Playwright image pull, or npm install failed). See the workflow logs."
+  } > "$OUT_DIR/comment.md"
+}
+
 cleanup() {
   for v in "${VARIATIONS[@]}"; do
     docker rm -f "shot-${v%%|*}" >/dev/null 2>&1 || true
   done
   docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  write_fallback_comment
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## What

Adds a CI workflow that, on every PR, renders the dashboard in all four flag combinations, screenshots each, and posts them inline as a sticky PR comment.

Variations captured (`INTERNAL_LB_ENABLED` × `KUBEADM_ENABLED`, on a long stress-test domain):

| name | flags |
|---|---|
| baseline | internal off · kubeadm off |
| internal | internal on · kubeadm off |
| kubeadm | kubeadm on · CA present |
| both | internal on · kubeadm on · CA present |

## How it works

- `e2e-screenshots/screenshot-variations.sh` — builds the image, runs each variation as a container on a private Docker network, drives a Playwright container to screenshot each, uploads the PNGs to **litterbox** (anonymous, no-auth, 72h auto-expiring host), and writes a ready-to-post Markdown comment. **Runnable locally with just Docker** (`./e2e-screenshots/screenshot-variations.sh`).
- `e2e-screenshots/pr-screenshots.mjs` — the Playwright capture + litterbox upload + comment generator.
- `.github/workflows/pr-screenshots.yaml` — runs the above on `pull_request`, posts the sticky comment, and uploads the PNGs as a workflow artifact backup.

## Notes

- **This PR contains only the tooling — no app change.** So the screenshots it posts capture **current `main` as a baseline**. The actual layout fix will land in a separate PR (branched from this once merged), whose screenshots will show the after-state.
- Litterbox is best-effort/no-SLA and images are world-readable; the artifact upload is the fallback.
- Fork PRs get a read-only token, so the sticky-comment step won't post there (they still get the artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)