### PR TITLE
fix: stop the dashboard sidebar and tool cards from stretching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,7 +198,7 @@ users:
 
           {/* Main Tool Grid */}
           <div className="lg:col-span-8">
-            <div data-testid="tool-grid" className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:h-full lg:auto-rows-fr">
+            <div data-testid="tool-grid" className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {tools.map((tool, i) => (
                 <Card key={i} className="bg-slate-800 border-slate-700 group hover:border-[#F4C624] transition-all duration-300 shadow-xl">
                   <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,7 +174,7 @@ users:
               <CardHeader>
                 <CardTitle style={subHeaderStyle} className="text-sm uppercase tracking-widest text-[#F4C624]">Network Endpoints</CardTitle>
               </CardHeader>
-              <CardContent data-testid="network-endpoints" className="grow flex flex-col justify-between gap-4">
+              <CardContent data-testid="network-endpoints" className="grow flex flex-col justify-start gap-4">
                 {domains.map((dom, i) => (
                   <div key={i} className="group p-3 rounded-md border border-slate-700 bg-slate-900/50 hover:border-[#F4C624]/50 transition-all">
                     <p style={subHeaderStyle} className="text-xs text-slate-500 uppercase flex items-center gap-2 mb-1">


### PR DESCRIPTION
## Problem

The dashboard's two columns use height-matching (`grow` on the sidebar, `lg:h-full lg:auto-rows-fr` on the tool grid), so whichever column is shorter **stretches to match the taller one**. Two symptoms of the same root cause, both surfaced by the long stress-test domain:

1. **kubeadm ON** → the tool grid gains a 5th card (Goldilocks) → grid is taller → the **Network Endpoints** sidebar stretches, spreading the endpoints apart with big gaps.
2. **internal LB ON, kubeadm OFF** → the sidebar gains a 4th endpoint while the grid has only 4 cards (2 rows) → the sidebar is taller → the **tool cards** balloon, floating the "Open Dashboard" button far below the description.

## Fix (`src/App.tsx`, two lines)

- Network Endpoints `CardContent`: `justify-between` → `justify-start` (rows stay stacked at the top).
- Tool grid: drop `lg:h-full lg:auto-rows-fr` (cards size to content instead of filling the sidebar height; cards in a row stay equal via the grid's default `align-items: stretch`).

Both are purely presentational; rendering is identical in the balanced cases and clean instead of stretched in the mismatched ones.

## Verification

The HTML-snapshot tests (`App.test.tsx`) are unaffected — both changes are on container `className`s, not the `innerHTML` those tests capture. That's exactly why this class of CSS-only regression needs a **visual** check. The PR screenshot workflow renders all four flag combinations; see the sticky comment on this PR for the after-state across `baseline`, `internal`, `kubeadm`, and `both`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)